### PR TITLE
[BUG] - Update timeseries range checks

### DIFF
--- a/nwbwidgets/timeseries.py
+++ b/nwbwidgets/timeseries.py
@@ -410,7 +410,8 @@ class SeparateTracesPlotlyWidget(AbstractTraceWidget):
                         self.out_fig.data[i].x = tt
                         self.out_fig.data[i].y = dd
                         self.out_fig.update_yaxes(
-                            range=[min(dd), max(dd)], row=i + 1, col=1
+                            range=[min(dd), max(dd)] if dd.size != 0 else [None, None],
+                            row=i + 1, col=1
                         )
                         self.out_fig.update_xaxes(
                             range=time_window, row=i + 1, col=1

--- a/nwbwidgets/timeseries.py
+++ b/nwbwidgets/timeseries.py
@@ -353,12 +353,15 @@ class SingleTracePlotlyWidget(AbstractTraceWidget):
             self.out_fig.data[0].x = get_timeseries_tt(timeseries, istart, istop)
             self.out_fig.data[0].y = list(yy)
 
+            # Get data y-range, catching case with no data in current range (if so - no update)
+            try:
+                y_range = [min(yy), max(yy)]
+            except ValueError:
+                y_range = [None, None]
+
             self.out_fig.update_layout(
-                yaxis={"range": [min(yy), max(yy)], "autorange": False},
-                xaxis={
-                    "range": [min(self.out_fig.data[0].x), max(self.out_fig.data[0].x)],
-                    "autorange": False,
-                },
+                yaxis={"range": y_range, "autorange": False},
+                xaxis={"range": time_window, "autorange": False},
             )
 
         self.controls["time_window"].observe(on_change)

--- a/nwbwidgets/timeseries.py
+++ b/nwbwidgets/timeseries.py
@@ -354,11 +354,7 @@ class SingleTracePlotlyWidget(AbstractTraceWidget):
             self.out_fig.data[0].y = list(yy)
 
             # Get data y-range, catching case with no data in current range (if so - no update)
-            try:
-                y_range = [min(yy), max(yy)]
-            except ValueError:
-                y_range = [None, None]
-
+            y_range = [min(yy), max(yy)] if yy.size != 0 else [None, None]
             self.out_fig.update_layout(
                 yaxis={"range": y_range, "autorange": False},
                 xaxis={"range": time_window, "autorange": False},

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -70,8 +70,8 @@ class TestTracesPlotlyWidget(unittest.TestCase):
             rate=1.0,
         )
         # Create 'intermittent' timeseries by defining timestamps with a gap from [10, 20]
-        self.ts_intermittent = TimeSeries(
-            name="test_timeseries_intermittent",
+        self.ts_single_intermittent = TimeSeries(
+            name="test_timeseries_single_intermittent",
             data=data[:, 0],
             timestamps=np.hstack([np.arange(0, 10, 10 / data.shape[0] * 2),
                                   np.arange(20, 30, 10 / data.shape[0] * 2)]),
@@ -87,17 +87,13 @@ class TestTracesPlotlyWidget(unittest.TestCase):
         ]
 
     def test_single_trace_widget_null_data(self):
-        single_wd = SingleTracePlotlyWidget(timeseries=self.ts_intermittent)
-        tt = get_timeseries_tt(self.ts_single, 12, 18)
-        single_wd.controls["time_window"].value = [
-            tt[int(len(tt) * 0.2)],
-            tt[int(len(tt) * 0.4)],
-        ]
+        single_wd_nd = SingleTracePlotlyWidget(timeseries=self.ts_intermittent)
+        single_wd_nd.controls["time_window"].value = [12, 14]
 
     def test_separate_traces_widget(self):
-        single_wd = SeparateTracesPlotlyWidget(timeseries=self.ts_multi)
+        sep_wd = SeparateTracesPlotlyWidget(timeseries=self.ts_multi)
         tt = get_timeseries_tt(self.ts_multi)
-        single_wd.controls["time_window"].value = [
+        sep_wd.controls["time_window"].value = [
             tt[int(len(tt) * 0.2)],
             tt[int(len(tt) * 0.4)],
         ]

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -78,7 +78,7 @@ class TestTracesPlotlyWidget(unittest.TestCase):
             tt[int(len(tt) * 0.4)],
         ]
 
-    def test_single_trace_widget(self):
+    def test_separate_traces_widget(self):
         single_wd = SeparateTracesPlotlyWidget(timeseries=self.ts_multi)
         tt = get_timeseries_tt(self.ts_multi)
         single_wd.controls["time_window"].value = [
@@ -138,41 +138,6 @@ class TestIndexTimeSeriesPlotly(unittest.TestCase):
             timeseries=self.ts_single,
             trace_range=[2, 5],
         )
-
-
-class TestTracesPlotlyWidget(unittest.TestCase):
-    def setUp(self):
-        data = np.random.rand(160, 3)
-        self.ts_multi = SpatialSeries(
-            name="test_timeseries",
-            data=data,
-            reference_frame="lowerleft",
-            starting_time=0.0,
-            rate=1.0,
-        )
-        self.ts_single = TimeSeries(
-            name="test_timeseries",
-            data=data[:, 0],
-            unit="m",
-            starting_time=0.0,
-            rate=1.0,
-        )
-
-    def test_single_trace_widget(self):
-        single_wd = SingleTracePlotlyWidget(timeseries=self.ts_single)
-        tt = get_timeseries_tt(self.ts_single)
-        single_wd.controls["time_window"].value = [
-            tt[int(len(tt) * 0.2)],
-            tt[int(len(tt) * 0.4)],
-        ]
-
-    def test_single_trace_widget(self):
-        single_wd = SeparateTracesPlotlyWidget(timeseries=self.ts_multi)
-        tt = get_timeseries_tt(self.ts_multi)
-        single_wd.controls["time_window"].value = [
-            tt[int(len(tt) * 0.2)],
-            tt[int(len(tt) * 0.4)],
-        ]
 
 
 class ShowTimeSeriesTestCase(unittest.TestCase):

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -69,10 +69,26 @@ class TestTracesPlotlyWidget(unittest.TestCase):
             starting_time=0.0,
             rate=1.0,
         )
+        # Create 'intermittent' timeseries by defining timestamps with a gap from [10, 20]
+        self.ts_intermittent = TimeSeries(
+            name="test_timeseries_intermittent",
+            data=data[:, 0],
+            timestamps=np.hstack([np.arange(0, 10, 10 / data.shape[0] * 2),
+                                  np.arange(20, 30, 10 / data.shape[0] * 2)]),
+            unit='m',
+        )
 
     def test_single_trace_widget(self):
         single_wd = SingleTracePlotlyWidget(timeseries=self.ts_single)
         tt = get_timeseries_tt(self.ts_single)
+        single_wd.controls["time_window"].value = [
+            tt[int(len(tt) * 0.2)],
+            tt[int(len(tt) * 0.4)],
+        ]
+
+    def test_single_trace_widget_null_data(self):
+        single_wd = SingleTracePlotlyWidget(timeseries=self.ts_intermittent)
+        tt = get_timeseries_tt(self.ts_single, 12, 18)
         single_wd.controls["time_window"].value = [
             tt[int(len(tt) * 0.2)],
             tt[int(len(tt) * 0.4)],

--- a/test/test_timeseries.py
+++ b/test/test_timeseries.py
@@ -56,14 +56,14 @@ class TestTracesPlotlyWidget(unittest.TestCase):
     def setUp(self):
         data = np.random.rand(160, 3)
         self.ts_multi = SpatialSeries(
-            name="test_timeseries",
+            name="test_timeseries_multi",
             data=data,
             reference_frame="lowerleft",
             starting_time=0.0,
             rate=1.0,
         )
         self.ts_single = TimeSeries(
-            name="test_timeseries",
+            name="test_timeseries_single",
             data=data[:, 0],
             unit="m",
             starting_time=0.0,
@@ -77,6 +77,14 @@ class TestTracesPlotlyWidget(unittest.TestCase):
                                   np.arange(20, 30, 10 / data.shape[0] * 2)]),
             unit='m',
         )
+        self.ts_multi_intermittent = SpatialSeries(
+            name="test_timeseries_multi_intermittent",
+            data=data,
+            timestamps=np.hstack([np.arange(0, 10, 10 / data.shape[0] * 2),
+                                  np.arange(20, 30, 10 / data.shape[0] * 2)]),
+            reference_frame="lowerleft",
+        )
+
 
     def test_single_trace_widget(self):
         single_wd = SingleTracePlotlyWidget(timeseries=self.ts_single)
@@ -87,7 +95,7 @@ class TestTracesPlotlyWidget(unittest.TestCase):
         ]
 
     def test_single_trace_widget_null_data(self):
-        single_wd_nd = SingleTracePlotlyWidget(timeseries=self.ts_intermittent)
+        single_wd_nd = SingleTracePlotlyWidget(timeseries=self.ts_single_intermittent)
         single_wd_nd.controls["time_window"].value = [12, 14]
 
     def test_separate_traces_widget(self):
@@ -97,6 +105,10 @@ class TestTracesPlotlyWidget(unittest.TestCase):
             tt[int(len(tt) * 0.2)],
             tt[int(len(tt) * 0.4)],
         ]
+
+    def test_separate_traces_widget_null_data(self):
+        single_wd_nd = SingleTracePlotlyWidget(timeseries=self.ts_multi_intermittent)
+        single_wd_nd.controls["time_window"].value = [12, 14]
 
 
 class TestIndexTimeSeriesPlotly(unittest.TestCase):


### PR DESCRIPTION
Responds to #217 

The current update updates the `SingleTracePlotyWidget` to deal with displaying a selected segment that happens to be empty. 

Updates:
- add a try / except for setting y-axis limits, and default to None if no data
- update x-axis limits to show the selected range, rather than the x-range from the data
    - Note: this changes behaviour a bit: previously updating data would autoscale to the range of the selected data (so if selecting 30 seconds, but data was only in range 5-25, it would show 5-25), whereas with this update the x-range will always match the selected range. This is an easy way to address this specific issue, but might not be a preferred way to do it? (An alternative is to add an extra try / except, and show empty range if no data, auto-scale if there is _any_ data (?))

Notes:
- if this solution is considered a good way to go, I think it probably wants to be similarly updated in `SeparateTracesPlotlyWidget` (`on_change` - lines ~398-421). 