### PR TITLE
remove ipysheet dependency and use ipydatagrid to display h5py.Datase…

### DIFF
--- a/nwbwidgets/version.py
+++ b/nwbwidgets/version.py
@@ -1,1 +1,1 @@
-version = "0.8.1"
+version = "0.9.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib
 scikit-image
 pynwb
 ipympl
-ipysheet
+ipydatagrid
 ipyvolume>=0.6.0a10
 ipywidgets
 plotly


### PR DESCRIPTION
fix #210 

remove ipysheet dependency and use ipydatagrid to display h5py.Datasets and DynamicTables (when possible)

This is needed for ipyidgets 8.0 compatibility.