### PR TITLE
Fix CI not running on external forks

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,8 @@
 name: Tests and coverage
-on: [push]
+
+on:
+  pull_request:
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
CI hasn't been triggering on forks, which led to an issue in #232 causing a bunch of tests to break. Fixes for those are upcoming from @h-mayorquin 

The core of the issue is the trigger condition was `push`, which only happens relative to the host repo during the final merge commit. You always want to use `pull_request` to allow trigger from outside parties; +/- it should give a prompt for first-time contributors for safety reasons, and they won't ever have access to private repo action secrets