### PR TITLE
Fix rendering of electrodes when 'x' column is not present

### DIFF
--- a/nwbwidgets/ecephys.py
+++ b/nwbwidgets/ecephys.py
@@ -85,7 +85,11 @@ class ElectrodeGroupsWidget(ValueWidget, widgets.HBox):
 
 def show_electrodes(electrodes_table):
     in_dict = dict(table=render_dataframe)
-    if np.isnan(electrodes_table.x[0]):  # position is not defined
+    if "x" in electrodes_table.colnames:
+        ccf_position = electrodes_table["x"][0]
+    else:
+        ccf_position = np.nan
+    if np.isnan(ccf_position):  # position is not defined
         in_dict.update(electrode_groups=ElectrodeGroupsWidget)
     else:
         subject = electrodes_table.get_ancestor("NWBFile").subject


### PR DESCRIPTION
Fixes the following error when `x` column is not present:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/anaconda3/envs/nwb/lib/python3.9/site-packages/ipywidgets/widgets/widget.py:766, in Widget._handle_msg(self, msg)
    764         if 'buffer_paths' in data:
    765             _put_buffers(state, data['buffer_paths'], msg['buffers'])
--> 766         self.set_state(state)
    768 # Handle a state request.
    769 elif method == 'request_state':

File ~/anaconda3/envs/nwb/lib/python3.9/site-packages/ipywidgets/widgets/widget.py:648, in Widget.set_state(self, sync_data)
    645 if name in self.keys:
    646     from_json = self.trait_metadata(name, 'from_json',
    647                                     self._trait_from_json)
--> 648     self.set_trait(name, from_json(sync_data[name], self))

File ~/anaconda3/envs/nwb/lib/python3.9/contextlib.py:126, in _GeneratorContextManager.__exit__(self, typ, value, traceback)
    124 if typ is None:
    125     try:
--> 126         next(self.gen)
    127     except StopIteration:
    128         return False

File ~/anaconda3/envs/nwb/lib/python3.9/site-packages/traitlets/traitlets.py:1498, in HasTraits.hold_trait_notifications(self)
   1496 for changes in cache.values():
   1497     for change in changes:
-> 1498         self.notify_change(change)

File ~/anaconda3/envs/nwb/lib/python3.9/site-packages/ipywidgets/widgets/widget.py:694, in Widget.notify_change(self, change)
    691     if name in self.keys and self._should_send_property(name, getattr(self, name)):
    692         # Send new state to front-end
    693         self.send_state(key=name)
--> 694 super().notify_change(change)

File ~/anaconda3/envs/nwb/lib/python3.9/site-packages/traitlets/traitlets.py:1513, in HasTraits.notify_change(self, change)
   1511 def notify_change(self, change):
   1512     """Notify observers of a change event"""
-> 1513     return self._notify_observers(change)

File ~/anaconda3/envs/nwb/lib/python3.9/site-packages/traitlets/traitlets.py:1560, in HasTraits._notify_observers(self, event)
   1557 elif isinstance(c, EventHandler) and c.name is not None:
   1558     c = getattr(self, c.name)
-> 1560 c(event)

File ~/Documents/codes/catalystneuro/nwbwidgets/nwbwidgets/base.py:157, in lazy_tabs.<locals>.on_selected_index(change)
    155 def on_selected_index(change):
    156     if isinstance(change.owner.children[change.new], widgets.HTML):
--> 157         children[change.new] = vis2widget(tabs_spec[change.new][1](node))
    158         change.owner.children = children

File ~/Documents/codes/catalystneuro/nwbwidgets/nwbwidgets/view.py:33, in show_dynamic_table(node, **kwargs)
     31 def show_dynamic_table(node, **kwargs) -> widgets.Widget:
     32     if node.name == "electrodes":
---> 33         return ecephys.show_electrodes(node)
     34     return base.render_dataframe(node)

File ~/Documents/codes/catalystneuro/nwbwidgets/nwbwidgets/ecephys.py:88, in show_electrodes(electrodes_table)
     86 def show_electrodes(electrodes_table):
     87     in_dict = dict(table=render_dataframe)
---> 88     if np.isnan(electrodes_table.x[0]):  # position is not defined
     89         in_dict.update(electrode_groups=ElectrodeGroupsWidget)
     90     else:

AttributeError: 'DynamicTable' object has no attribute 'x'
```