### PR TITLE
Relax upper bound on ipywidgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 # v0.10.1
 
 * Added a trialized widget for TimeSeries. [PR #232](https://github.com/NeurodataWithoutBorders/nwbwidgets/pull/232)
+* Loosened upper bound version on `ipywidgets`. [PR #260](https://github.com/NeurodataWithoutBorders/nwbwidgets/pull/260)

--- a/nwbwidgets/base.py
+++ b/nwbwidgets/base.py
@@ -182,7 +182,7 @@ def lazy_show_over_data(list_, func_, labels=None, style: GroupingWidget = widge
     children = [vis2widget(func_(list_[0]))] + [widgets.HTML("Rendering...") for _ in range(len(list_) - 1)]
     out = style(children=children)
     if labels is not None:
-        [out.set_title(i, label) for i, label in enumerate(labels)]
+        [out.set_title(i, str(label)) for i, label in enumerate(labels)]
 
     def on_selected_index(change):
         if change.new is not None and isinstance(change.owner.children[change.new], widgets.HTML):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pynwb
 ipympl
 ipydatagrid
 ipyvolume>=0.6.0a10
-ipywidgets>=7.4.0, <8.0.0
+ipywidgets>=8.0.0
 plotly
 tqdm>=4.36.0
 zarr


### PR DESCRIPTION
@bendichter Satra needs looser bounds on ipywidgets to get the Hub rebuild of default kernels to work smoothly

The versions above `ipywidgets>=8.0.0` fix the javascript issue