### PR TITLE
Update deprecated numpy types

### DIFF
--- a/nwbwidgets/brains.py
+++ b/nwbwidgets/brains.py
@@ -101,7 +101,7 @@ class HumanElectrodesPlotlyWidget(widgets.VBox):
             colors = group_inv
             show_leg = True
             show_scale = False
-        elif isinstance(electrodes[color_by][0], (np.ndarray, np.float)):
+        elif isinstance(electrodes[color_by][0], (np.ndarray, float)):
             colors = np.ravel(electrodes[color_by][:])
             ugroups, group_inv = [0], np.array([0] * len(colors))
             show_leg = False

--- a/nwbwidgets/controllers/group_and_sort_controllers.py
+++ b/nwbwidgets/controllers/group_and_sort_controllers.py
@@ -193,7 +193,7 @@ class GroupAndSortController(AbstractGroupAndSortController):
             self.group_sm.layout.visibility = "visible"
             self.group_sm.layout.width = "100px"
             keep_column_values = self.column_values
-            if self.column_values.dtype == np.float:
+            if isinstance(self.column_values.dtype, (float, np.floating)):
                 keep_column_values = keep_column_values[~np.isnan(keep_column_values)]
             groups = np.unique(keep_column_values)
             self.group_sm.rows = min(len(groups), 20)

--- a/nwbwidgets/misc.py
+++ b/nwbwidgets/misc.py
@@ -782,7 +782,7 @@ def raster_grid(
     if rows_label is not None:
         row_vals = np.array(time_intervals[rows_label][:])
         urow_vals = np.unique(row_vals[trials_select])
-        if urow_vals.dtype == float:
+        if isinstance(urow_vals.dtype, (float, np.floating)):
             urow_vals = urow_vals[~np.isnan(urow_vals)]
 
     else:
@@ -792,7 +792,7 @@ def raster_grid(
     if cols_label is not None:
         col_vals = np.array(time_intervals[cols_label][:])
         ucol_vals = np.unique(col_vals[trials_select])
-        if ucol_vals.dtype == float:
+        if isinstance(ucol_vals.dtype, (float, np.floating)):
             ucol_vals = ucol_vals[~np.isnan(ucol_vals)]
 
     else:

--- a/nwbwidgets/misc.py
+++ b/nwbwidgets/misc.py
@@ -782,7 +782,7 @@ def raster_grid(
     if rows_label is not None:
         row_vals = np.array(time_intervals[rows_label][:])
         urow_vals = np.unique(row_vals[trials_select])
-        if urow_vals.dtype == np.float64:
+        if urow_vals.dtype == float:
             urow_vals = urow_vals[~np.isnan(urow_vals)]
 
     else:
@@ -792,7 +792,7 @@ def raster_grid(
     if cols_label is not None:
         col_vals = np.array(time_intervals[cols_label][:])
         ucol_vals = np.unique(col_vals[trials_select])
-        if ucol_vals.dtype == np.float64:
+        if ucol_vals.dtype == float:
             ucol_vals = ucol_vals[~np.isnan(ucol_vals)]
 
     else:


### PR DESCRIPTION
* exception raised as of numpy 1.24.0 for using `np.float`:
https://numpy.org/doc/stable/release/1.24.0-notes.html
* `np.integer` still okay to check against abc for all numpy ints
* also searched master branch for any use of: `np.object`, `np.bool`, `np.float`, `np.complex`, `np.str`, `np.int`
* found a use of dtype check against `np.float64` in `nwbwidgets/misc.py`, which is still okay, but updated anyway to include built-in and all numpy floating point types 