### PR TITLE
fix #296

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming
 
+### Fixes
+* Fix plotly Figure not showing up, pinned Plotly version [PR #297](https://github.com/NeurodataWithoutBorders/nwbwidgets/pull/297)
+* Fix BehavioralTimeSeries not showing up [PR #297](https://github.com/NeurodataWithoutBorders/nwbwidgets/pull/297)
+
+
 # v0.10.2
 
 ### Fixes

--- a/nwbwidgets/behavior.py
+++ b/nwbwidgets/behavior.py
@@ -1,11 +1,11 @@
 from abc import abstractmethod
-
+from typing import Union
 import ipywidgets as widgets
 import matplotlib.pyplot as plt
 import numpy as np
 from plotly import graph_objects as go
 from pynwb import TimeSeries
-from pynwb.behavior import BehavioralEvents, SpatialSeries
+from pynwb.behavior import BehavioralEvents, SpatialSeries, BehavioralTimeSeries
 
 from .base import dict2accordion, lazy_tabs
 from .controllers import StartAndDurationController
@@ -23,7 +23,7 @@ from .utils.timeseries import (
 )
 
 
-def show_behavioral_events(beh_events: BehavioralEvents, neurodata_vis_spec: dict):
+def show_behavioral_events(beh_events: Union[BehavioralEvents, BehavioralTimeSeries], neurodata_vis_spec: dict):
     return dict2accordion(beh_events.time_series, neurodata_vis_spec, ls="", marker="|")
 
 

--- a/nwbwidgets/timeseries.py
+++ b/nwbwidgets/timeseries.py
@@ -146,7 +146,7 @@ def show_indexed_timeseries_plotly(
     zero_start=False,
     scatter_kwargs: dict = None,
     figure_kwargs: dict = None,
-):
+) -> go.FigureWidget:
     if istart != 0 or istop is not None:
         if time_window is not None:
             raise ValueError("input either time window or istart/stop but not both")

--- a/nwbwidgets/view.py
+++ b/nwbwidgets/view.py
@@ -104,6 +104,7 @@ default_neurodata_vis_spec = {
     pynwb.image.ImageSeries: ImageSeriesWidget,
     pynwb.image.IndexSeries: show_index_series,
     pynwb.TimeSeries: show_timeseries,
+    pynwb.behavior.BehavioralTimeSeries: show_behavioral_events,
     pynwb.core.MultiContainerInterface: show_multi_container_interface,
     pynwb.core.NWBContainer: show_neurodata_base,
     pynwb.core.NWBDataInterface: show_neurodata_base,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ipympl
 ipydatagrid
 ipyvolume>=0.6.0a10
 ipywidgets>=8.0.0
-plotly
+plotly==5.15.0
 tqdm>=4.36.0
 zarr
 tifffile


### PR DESCRIPTION
Fix #296 

- use `show_behavioral_events` function for BehavioralTimeSeries
- fix plotly version on requirements (ref: https://github.com/plotly/plotly.py/issues/3686)