### PR TITLE
Fix `compute_smoothed_firing_rate` binning behavior to match conventional histogram binning

### DIFF
--- a/nwbwidgets/analysis/spikes.py
+++ b/nwbwidgets/analysis/spikes.py
@@ -17,7 +17,8 @@ def compute_smoothed_firing_rate(spike_times, tt, sigma_in_secs):
     if len(spike_times) < 2:
         return np.zeros_like(tt)
     binned_spikes = np.zeros_like(tt)
-    binned_spikes[np.searchsorted(tt, spike_times)] += 1
+    spike_idx = np.searchsorted(tt, spike_times, side='right') - 1
+    np.add.at(binned_spikes, spike_idx, 1)
     dt = np.diff(tt[:2])[0]
     sigma_in_samps = sigma_in_secs / dt
     smooth_fr = scipy.ndimage.gaussian_filter1d(binned_spikes, sigma_in_samps) / dt

--- a/nwbwidgets/analysis/spikes.py
+++ b/nwbwidgets/analysis/spikes.py
@@ -14,11 +14,16 @@ def compute_smoothed_firing_rate(spike_times, tt, sigma_in_secs):
     Returns:
           Gaussian smoothing evaluated at array t
     """
-    if len(spike_times) < 2:
+    if len(spike_times) < 1:
         return np.zeros_like(tt)
     binned_spikes = np.zeros_like(tt)
+    # find bin indices for spike times
     spike_idx = np.searchsorted(tt, spike_times, side='right') - 1
+    # filter out negative spike idxs, though there shouldn't be any
+    spike_idx = spike_idx[spike_idx >= 0].astype(int)
+    # increment binned spike count at bin indices
     np.add.at(binned_spikes, spike_idx, 1)
+    # smooth data
     dt = np.diff(tt[:2])[0]
     sigma_in_samps = sigma_in_secs / dt
     smooth_fr = scipy.ndimage.gaussian_filter1d(binned_spikes, sigma_in_samps) / dt

--- a/test/test_analysis_spikes.py
+++ b/test/test_analysis_spikes.py
@@ -1,0 +1,14 @@
+import numpy as np
+from nwbwidgets.analysis.spikes import compute_smoothed_firing_rate
+
+
+def test_compute_smoothed_firing_rate():
+    spike_times = np.array([1.0, 2.0, 5.0, 5.5, 7.0, 7.5, 8.0])
+    tt = np.arange(10, dtype=float)
+    expected_binned_spikes = np.array([0.0, 1.0, 1.0, 0.0, 0.0, 2.0, 0.0, 2.0, 1.0, 0.0])
+    expected_smoothed_spikes = np.array([0.35438556, 0.64574827, 0.64991247, 0.40421249, 0.55136343,
+        0.91486675, 1.02201074, 1.14797447, 0.89644961, 0.41307621])
+    binned_spikes = compute_smoothed_firing_rate(spike_times, tt, 0.001)
+    smoothed_spikes = compute_smoothed_firing_rate(spike_times, tt, 1.0)
+    np.testing.assert_allclose(expected_binned_spikes, binned_spikes)
+    np.testing.assert_allclose(expected_smoothed_spikes, smoothed_spikes)


### PR DESCRIPTION
Some fixes for the issues raised in #313, unless any of those are actually intentional/desirable