### PR TITLE
Add default visualisation for `OnePhotonSeries`

### DIFF
--- a/nwbwidgets/ophys.py
+++ b/nwbwidgets/ophys.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Union
 
 import ipywidgets as widgets
 import numpy as np
@@ -11,6 +12,7 @@ from pynwb.ophys import (
     ImageSegmentation,
     PlaneSegmentation,
     RoiResponseSeries,
+    OnePhotonSeries,
     TwoPhotonSeries,
 )
 from skimage import measure
@@ -25,10 +27,10 @@ from .utils.dynamictable import infer_categorical_columns
 color_wheel = px.colors.qualitative.Dark24
 
 
-class TwoPhotonSeriesWidget(widgets.VBox):
-    """Widget showing Image stack recorded over time from 2-photon microscope."""
+class PhotonSeriesWidget(widgets.VBox):
+    """Widget showing Image stack recorded over time from 2-photon or 1-photon microscope."""
 
-    def __init__(self, indexed_timeseries: TwoPhotonSeries, neurodata_vis_spec: dict):
+    def __init__(self, indexed_timeseries: Union[TwoPhotonSeries, OnePhotonSeries], neurodata_vis_spec: dict):
         super().__init__()
 
         def _add_fig_trace(img_fig: go.Figure, index):

--- a/nwbwidgets/view.py
+++ b/nwbwidgets/view.py
@@ -42,7 +42,7 @@ from .misc import (
 )
 from .ophys import (
     RoiResponseSeriesWidget,
-    TwoPhotonSeriesWidget,
+    PhotonSeriesWidget,
     route_plane_segmentation,
     show_df_over_f,
     show_grayscale_volume,
@@ -78,7 +78,8 @@ default_neurodata_vis_spec = {
     pynwb.file.Subject: show_fields,
     pynwb.ecephys.SpikeEventSeries: show_spike_event_series,
     pynwb.ophys.ImageSegmentation: show_image_segmentation,
-    pynwb.ophys.TwoPhotonSeries: TwoPhotonSeriesWidget,
+    pynwb.ophys.TwoPhotonSeries: PhotonSeriesWidget,
+    pynwb.ophys.OnePhotonSeries: PhotonSeriesWidget,
     ndx_grayscalevolume.GrayscaleVolume: show_grayscale_volume,
     pynwb.ophys.PlaneSegmentation: route_plane_segmentation,
     pynwb.ophys.DfOverF: show_df_over_f,

--- a/test/test_ophys.py
+++ b/test/test_ophys.py
@@ -11,13 +11,13 @@ from pynwb.ophys import (
     ImagingPlane,
     OpticalChannel,
     PlaneSegmentation,
-    TwoPhotonSeries,
+    TwoPhotonSeries, OnePhotonSeries,
 )
 from pynwb.testing.mock.ophys import mock_PlaneSegmentation
 
 from nwbwidgets.ophys import (
     PlaneSegmentation2DWidget,
-    TwoPhotonSeriesWidget,
+    PhotonSeriesWidget,
     show_df_over_f,
     show_grayscale_volume,
     show_image_segmentation,
@@ -61,6 +61,16 @@ class CalciumImagingTestCase(unittest.TestCase):
             rate=1.0,
             unit="n.a",
         )
+
+        self.one_photon_series = OnePhotonSeries(
+            name="test_one_photon_series",
+            data=np.random.randn(100, 5, 5),
+            imaging_plane=self.imaging_plane,
+            starting_frame=[0],
+            rate=1.0,
+            unit="n.a.",
+        )
+
         self.img_seg = ImageSegmentation()
         self.ps2 = self.img_seg.create_plane_segmentation(
             "output from segmenting my favorite imaging plane",
@@ -105,7 +115,7 @@ class CalciumImagingTestCase(unittest.TestCase):
         self.df_over_f = DfOverF(rrs)
 
     def test_show_two_photon_series(self):
-        wid = TwoPhotonSeriesWidget(self.image_series, default_neurodata_vis_spec)
+        wid = PhotonSeriesWidget(self.image_series, default_neurodata_vis_spec)
         assert isinstance(wid, widgets.Widget)
         wid.controls["slider"].value = 50
 
@@ -118,7 +128,12 @@ class CalciumImagingTestCase(unittest.TestCase):
             rate=1.0,
             unit="n.a",
         )
-        wid = TwoPhotonSeriesWidget(image_series3, default_neurodata_vis_spec)
+        wid = PhotonSeriesWidget(image_series3, default_neurodata_vis_spec)
+        assert isinstance(wid, widgets.Widget)
+        wid.controls["slider"].value = 50
+
+    def test_show_one_photon_series(self):
+        wid = PhotonSeriesWidget(self.one_photon_series, default_neurodata_vis_spec)
         assert isinstance(wid, widgets.Widget)
         wid.controls["slider"].value = 50
 


### PR DESCRIPTION
- Uses the same widget as `pynwb.ophys.TwoPhotonSeries`
- The widget is renamed to `PhotonSeriesWidget` to better represent it can be used both for `pynwb.ophys.TwoPhotonSeries` and `pynwb.ophys.OnePhotonSeries`

Demo screenshot:
<img width="1128" alt="Screenshot 2023-10-27 at 17 05 55 (2)" src="https://github.com/NeurodataWithoutBorders/nwbwidgets/assets/24475788/f77bef51-dc9b-4248-80ba-65dd8034bc24">
